### PR TITLE
fixes WSOD on Drupal 8.4.0 and later

### DIFF
--- a/image_field_caption.services.yml
+++ b/image_field_caption.services.yml
@@ -2,6 +2,6 @@ services:
   image_field_caption.storage:
     class: Drupal\image_field_caption\ImageCaptionStorage
     arguments:
-      - @cache.data
-      - @cache_tags.invalidator
-      - @database
+      - '@cache.data'
+      - '@cache_tags.invalidator'
+      - '@database'


### PR DESCRIPTION
On Drupal 8.4.0 and later the module causes a WSOD. Drush doesnt work either. There is a YAML Exception (Drupal\Component\Serialization\Exception\InvalidDataTypeException) for your image_field_caption.services.yml file on Drupal\Component\Serialization\Yaml::decode. looks like wrapping those bad boys in a single quote did the trick